### PR TITLE
Fixes #34 - Filter by outfields before creating fields

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -75,15 +75,16 @@ function isInt (value) {
 function computeFieldObject (data, template, options) {
   let oid = false
   const metadata = data.metadata || {}
+  let metadataFields = metadata.fields
+  if (!metadataFields && data.statistics) return computeFields(data.statistics[0], template, options).fields
+  else if (!metadataFields) return computeAggFieldObject(data, template, options)
 
-  if (!metadata.fields && data.statistics) return computeFields(data.statistics[0], template, options).fields
-  else if (!metadata.fields) return computeAggFieldObject(data, template, options)
-
-  var outFields = options.outFields.split(",")
-  var metadataFields = metadata.fields.filter((field) => {
-    if(outFields.indexOf(field.name) > -1){ return field }
-  });
-
+  if(options.outFields){
+    var outFields = options.outFields.split(",")
+    metadataFields = metadata.fields.filter((field) => {
+      if(outFields.indexOf(field.name) > -1){ return field }
+    });
+  }
   const fields = metadataFields.map(field => {
     if (field.name === metadata.idField || field.name.toLowerCase() === 'objectid') oid = true
     const template = _.cloneDeep(templates.field)
@@ -93,7 +94,6 @@ function computeFieldObject (data, template, options) {
       alias: field.alias || field.name
     })
   })
-
   if (!oid) fields.push(templates.objectIDField)
   return fields
 }

--- a/src/field.js
+++ b/src/field.js
@@ -79,7 +79,12 @@ function computeFieldObject (data, template, options) {
   if (!metadata.fields && data.statistics) return computeFields(data.statistics[0], template, options).fields
   else if (!metadata.fields) return computeAggFieldObject(data, template, options)
 
-  const fields = metadata.fields.map(field => {
+  var outFields = options.outFields.split(",")
+  var metadataFields = metadata.fields.filter((field) => {
+    if(outFields.indexOf(field.name) > -1){ return field }
+  });
+
+  const fields = metadataFields.map(field => {
     if (field.name === metadata.idField || field.name.toLowerCase() === 'objectid') oid = true
     const template = _.cloneDeep(templates.field)
     return Object.assign({}, template, {


### PR DESCRIPTION
Feature Server is ignoring the outFields options when generating the fields response.  Therefore, when clients get the response they think the Feature Set response contains these fields, when if fact it may not.  So before creating fields, this fix filters ``` metadata.fields``` so that it will only contain fields contained in the ``` outFields ``` options.

Give this request to Feature Server: (note date, OBJECTID in outfields)

``` FeatureServer/0/query?f=json&geometry={%22xmin%22:-13633964.480821775,%22ymin%22:4540069.018923454,%22xmax%22:-13618753.512193045,%22ymax%22:4553904.1210430525}&geometryType=esriGeometryEnvelope&inSR=102100&spatialRel=esriSpatialRelIntersects&outFields=date,OBJECTID&returnGeometry=true&maxAllowableOffset=38&outSR=102100&resultOffset=0&resultRecordCount=1000&where=1=1```

Before this fix the fields response will look like this: 

```
  "fields": [
    {
      "name": "date",
      "type": "esriFieldTypeDate",
      "alias": "date",
      "length": null,
      "editable": false,
      "nullable": true,
      "domain": null
    },
    {
      "name": "description",
      "type": "esriFieldTypeString",
      "alias": "description",
      "length": null,
      "editable": false,
      "nullable": true,
      "domain": null
    },
    {
      "name": "title",
      "type": "esriFieldTypeString",
      "alias": "title",
      "length": null,
      "editable": false,
      "nullable": true,
      "domain": null
    },
    {
      "name": "OBJECTID",
      "type": "esriFieldTypeOID",
      "alias": "ID",
      "length": null,
      "editable": false,
      "nullable": false,
      "domain": null
    }
  ]

```

After this fix the fields the response will look like this, b/ outfields contains data :

```
  "fields": [
    {
      "name": "date",
      "type": "esriFieldTypeDate",
      "alias": "date",
      "length": null,
      "editable": false,
      "nullable": true,
      "domain": null
    },
    {
      "name": "OBJECTID",
      "type": "esriFieldTypeOID",
      "alias": "ID",
      "length": null,
      "editable": false,
      "nullable": false,
      "domain": null
    }
  ]

```

If outFields does not contain data it will look like this (per commit 89d35e1).

```
  "fields": [
    {
      "name": "date",
      "type": "esriFieldTypeDate",
      "alias": "date",
      "length": null,
      "editable": false,
      "nullable": true,
      "domain": null
    },
    {
      "name": "description",
      "type": "esriFieldTypeString",
      "alias": "description",
      "length": null,
      "editable": false,
      "nullable": true,
      "domain": null
    },
    {
      "name": "title",
      "type": "esriFieldTypeString",
      "alias": "title",
      "length": null,
      "editable": false,
      "nullable": true,
      "domain": null
    },
    {
      "name": "OBJECTID",
      "type": "esriFieldTypeOID",
      "alias": "ID",
      "length": null,
      "editable": false,
      "nullable": false,
      "domain": null
    }
  ]

```


See #34 